### PR TITLE
Fix seed data migration formatting

### DIFF
--- a/Migrations/20250921021947_SeedDataRailway.cs
+++ b/Migrations/20250921021947_SeedDataRailway.cs
@@ -123,25 +123,70 @@ namespace EcommerceBackend.Migrations
             migrationBuilder.InsertData(
                 table: "CartItems",
                 columns: new[] { "Id", "CreatedAt", "ProductId", "Quantity", "UserId" },
-                values: new object[] { new Guid("1e8537ac-5a83-4f32-9ba5-248358dae55a"), new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4192), new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"), 2, new Guid("d60ec960-bc53-424a-9128-5275fbd4969f") });
+                values: new object[]
+                {
+                    new Guid("1e8537ac-5a83-4f32-9ba5-248358dae55a"),
+                    new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4192),
+                    new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                    2,
+                    new Guid("d60ec960-bc53-424a-9128-5275fbd4969f")
+                });
 
             migrationBuilder.InsertData(
                 table: "Invoices",
                 columns: new[] { "Id", "BillingAddress", "CreatedAt", "InvoiceNumber", "PaidAt", "Status", "Tax", "Total", "UserId" },
-                values: new object[] { new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"), "Calle Falsa 123", new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4258), "INV-001", new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4267), "Paid", 0m, 70m, new Guid("d60ec960-bc53-424a-9128-5275fbd4969f") });
+                values: new object[]
+                {
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    "Calle Falsa 123",
+                    new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4258),
+                    "INV-001",
+                    new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4267),
+                    "Paid",
+                    0m,
+                    70m,
+                    new Guid("d60ec960-bc53-424a-9128-5275fbd4969f")
+                });
 
             migrationBuilder.InsertData(
                 table: "Payments",
                 columns: new[] { "Id", "Amount", "CreatedAt", "InvoiceId", "Provider", "ProviderPaymentId", "Status" },
-                values: new object[] { new Guid("cb361e92-3347-46f6-8568-8c1671dfbd8d"), 70m, new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4383), new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"), "Stripe", "pay_001", "Completed" });
+                values: new object[]
+                {
+                    new Guid("cb361e92-3347-46f6-8568-8c1671dfbd8d"),
+                    70m,
+                    new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4383),
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    "Stripe",
+                    "pay_001",
+                    "Completed"
+                });
 
             migrationBuilder.InsertData(
                 table: "Products",
                 columns: new[] { "Id", "Category", "CreatedAt", "Description", "ImageUrl", "Name", "Price", "Stock" },
                 values: new object[,]
                 {
-                    { new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"), "Accesorios", new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4106), "Mouse Bluetooth ergonómico", "", "Mouse Inalámbrico", 35m, 50 },
-                    { new Guid("488e5e0f-e6eb-44a3-a587-9c3e5f6c5e7b"), "Electrónica", new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4094), "Laptop potente para gaming", "", "Laptop Gamer", 1500m, 10 }
+                    {
+                        new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                        "Accesorios",
+                        new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4106),
+                        "Mouse Bluetooth ergonómico",
+                        string.Empty,
+                        "Mouse Inalámbrico",
+                        35m,
+                        50
+                    },
+                    {
+                        new Guid("488e5e0f-e6eb-44a3-a587-9c3e5f6c5e7b"),
+                        "Electrónica",
+                        new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc).AddTicks(4094),
+                        "Laptop potente para gaming",
+                        string.Empty,
+                        "Laptop Gamer",
+                        1500m,
+                        10
+                    }
                 });
 
             migrationBuilder.InsertData(
@@ -149,14 +194,36 @@ namespace EcommerceBackend.Migrations
                 columns: new[] { "Id", "CreatedAt", "Email", "FullName", "PasswordHash", "Role" },
                 values: new object[,]
                 {
-                    { new Guid("89b8105d-38e1-4849-abe3-d7c20b99d8a4"), new DateTime(2025, 9, 21, 2, 19, 46, 202, DateTimeKind.Utc).AddTicks(1762), "admin@ecommerce.com", "Admin", "$2a$11$a4XTN3Qs2Pls1KQrRWDlNOEEOLNW5Tn9lUHGYAl0wlgg5cYmHT4f.", "admin" },
-                    { new Guid("d60ec960-bc53-424a-9128-5275fbd4969f"), new DateTime(2025, 9, 21, 2, 19, 46, 468, DateTimeKind.Utc).AddTicks(7329), "user@ecommerce.com", "Usuario Test", "$2a$11$SBZkm5ho6nodxsu1bjQYKeV5rUlWPqwLMxNYvvSZtEkJRD4uHrSjm", "user" }
+                    {
+                        new Guid("89b8105d-38e1-4849-abe3-d7c20b99d8a4"),
+                        new DateTime(2025, 9, 21, 2, 19, 46, 202, DateTimeKind.Utc).AddTicks(1762),
+                        "admin@ecommerce.com",
+                        "Admin",
+                        "$2a$11$a4XTN3Qs2Pls1KQrRWDlNOEEOLNW5Tn9lUHGYAl0wlgg5cYmHT4f.",
+                        "admin"
+                    },
+                    {
+                        new Guid("d60ec960-bc53-424a-9128-5275fbd4969f"),
+                        new DateTime(2025, 9, 21, 2, 19, 46, 468, DateTimeKind.Utc).AddTicks(7329),
+                        "user@ecommerce.com",
+                        "Usuario Test",
+                        "$2a$11$SBZkm5ho6nodxsu1bjQYKeV5rUlWPqwLMxNYvvSZtEkJRD4uHrSjm",
+                        "user"
+                    }
                 });
 
             migrationBuilder.InsertData(
                 table: "InvoiceItems",
                 columns: new[] { "Id", "InvoiceId", "LineTotal", "ProductId", "Quantity", "UnitPrice" },
-                values: new object[] { new Guid("c8633a68-aea5-4904-a9b5-5a15de248cc4"), new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"), 70m, new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"), 2, 35m });
+                values: new object[]
+                {
+                    new Guid("c8633a68-aea5-4904-a9b5-5a15de248cc4"),
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    70m,
+                    new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                    2,
+                    35m
+                });
 
             migrationBuilder.CreateIndex(
                 name: "IX_InvoiceItems_InvoiceId",


### PR DESCRIPTION
## Summary
- correct formatting of seed data insertion in the 20250921021947_SeedDataRailway migration
- ensure DateTime constructors, GUIDs, and string literals are written without unintended line breaks
- use string.Empty for empty image URLs to avoid malformed string constants

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dd472e9c8333a4192d04f9f65205