### PR TITLE
Fix default role lookup in AuthController

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using EcommerceBackend.Data;
@@ -35,6 +36,7 @@ namespace EcommerceBackend.Controllers
                 return BadRequest(new { error = "La contraseña debe tener al menos 6 caracteres" });
 
             var normalizedEmail = email.ToLowerInvariant();
+            var defaultRole = User.FindFirstValue(ClaimTypes.Role) ?? "customer";
 
             if (await _db.Users.AsNoTracking().AnyAsync(u => u.NormalizedEmail == normalizedEmail))
                 return Conflict(new { error = "El correo electrónico ya está registrado" });
@@ -44,7 +46,8 @@ namespace EcommerceBackend.Controllers
                 Email = email,
                 NormalizedEmail = normalizedEmail,
                 FullName = fullName,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(password)
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(password),
+                Role = defaultRole
             };
 
             await _db.Users.AddAsync(user);


### PR DESCRIPTION
## Summary
- ensure AuthController derives the default role from the current claims principal when registering a new user

## Testing
- dotnet publish EcommerceBackend.csproj -c Release *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f5694528833386bc3daedbaf8bf7