### PR TITLE
Ensure JWT signing key configuration is validated

### DIFF
--- a/Models/TokenService.cs
+++ b/Models/TokenService.cs
@@ -1,9 +1,9 @@
-using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
 using EcommerceBackend.Models;
+using EcommerceBackend.Security;
 using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 namespace EcommerceBackend.Services
 {
@@ -21,9 +21,8 @@ namespace EcommerceBackend.Services
                 new Claim(ClaimTypes.Role, user.Role)
             };
 
-            var key = new SymmetricSecurityKey(
-                Encoding.UTF8.GetBytes(_config["Jwt:Key"] ?? Environment.GetEnvironmentVariable("Jwt__Key") ?? "devkey")
-            );
+            var signingKey = JwtKeyProvider.GetSigningKey(_config);
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
             var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
             var token = new JwtSecurityToken(

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,11 @@
+using EcommerceBackend.Data;
+using EcommerceBackend.Services;
+using EcommerceBackend.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
-using EcommerceBackend.Data;
-using EcommerceBackend.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,9 +32,7 @@ builder.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(conn));
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
     {
-        var key = builder.Configuration["Jwt:Key"] 
-                  ?? Environment.GetEnvironmentVariable("Jwt__Key") 
-                  ?? "devkey";
+        var signingKey = JwtKeyProvider.GetSigningKey(builder.Configuration);
 
         options.TokenValidationParameters = new TokenValidationParameters
         {
@@ -41,7 +40,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             ValidateAudience = false,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey))
         };
     });
 

--- a/RAILWAY_INSTRUCTIONS.txt
+++ b/RAILWAY_INSTRUCTIONS.txt
@@ -2,7 +2,7 @@ Railway deployment notes:
 - Add PostgreSQL plugin in Railway (creates DATABASE_URL).
 - In Railway env variables add:
   ConnectionStrings__DefaultConnection = Host=host;Port=port;Database=dbname;Username=user;Password=pass
-  Jwt__Key = <secret>
+  Jwt__Key = <secret at least 16 bytes long>
 - Railway will build Dockerfile; ensure service exposes port 5000.
 - For frontend, set VITE_API_BASE_URL to the backend Railway URL + /api
 - See README for more details.

--- a/Security/JwtKeyProvider.cs
+++ b/Security/JwtKeyProvider.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace EcommerceBackend.Security
+{
+    public static class JwtKeyProvider
+    {
+        private const int MinimumKeyBytes = 16;
+
+        public static string GetSigningKey(IConfiguration configuration)
+        {
+            var key = configuration["Jwt:Key"] ?? Environment.GetEnvironmentVariable("Jwt__Key");
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new InvalidOperationException(
+                    "A JWT signing key was not configured. Provide a value for 'Jwt:Key' or the 'Jwt__Key' environment variable."
+                );
+            }
+
+            if (Encoding.UTF8.GetByteCount(key) < MinimumKeyBytes)
+            {
+                throw new InvalidOperationException(
+                    "The configured JWT signing key must be at least 16 bytes long when encoded as UTF-8."
+                );
+            }
+
+            return key;
+        }
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,9 +1,9 @@
 {
   "ConnectionStrings": {
-"DefaultConnection": "Host=yamanote.proxy.rlwy.net;Port=34149;Database=railway;Username=postgres;Password=JEUavToEcbYDssxVwneizwsxeFQmNcfH;Trust Server Certificate=true"
+    "DefaultConnection": "Host=yamanote.proxy.rlwy.net;Port=34149;Database=railway;Username=postgres;Password=JEUavToEcbYDssxVwneizwsxeFQmNcfH;Trust Server Certificate=true"
   },
   "Jwt": {
-    "Key": "postgres"
+    "Key": "ChangeThisDevelopmentJwtKeyToBeSecure!"
   },
   "Logging": {
     "LogLevel": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on: ['db']
     environment:
       - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=ecommercedb;Username=postgres;Password=postgres
-      - Jwt__Key=DevelopmentJwtKey12345
+      - Jwt__Key=ChangeThisDevelopmentJwtKeyToBeSecure!
     ports: ['5000:5000']
   frontend:
     build:


### PR DESCRIPTION
## Summary
- centralize JWT signing key retrieval with validation to guarantee a minimum key length
- apply the shared key provider to the token service and JWT bearer authentication middleware
- document compliant JWT secrets in configuration and deployment guidance so the app runs with a secure sample value

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d60beb70f883338a21f45f86f65104