### PR TITLE
Handle missing user role when issuing tokens

### DIFF
--- a/Models/TokenService.cs
+++ b/Models/TokenService.cs
@@ -14,11 +14,13 @@ namespace EcommerceBackend.Services
 
         public string GenerateToken(User user)
         {
+            var role = string.IsNullOrWhiteSpace(user.Role) ? "customer" : user.Role;
+
             var claims = new[]
             {
                 new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
                 new Claim(JwtRegisteredClaimNames.Email, user.Email),
-                new Claim(ClaimTypes.Role, user.Role)
+                new Claim(ClaimTypes.Role, role)
             };
 
             var key = new SymmetricSecurityKey(


### PR DESCRIPTION
## Summary
- ensure JWT tokens default to the customer role when a user record lacks a role value

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d61217de008333ba414d58ada0f11c