### PR TITLE
Handle HTTPS redirection only in production

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -60,7 +60,10 @@ app.UseSwaggerUI(c =>
     c.RoutePrefix = string.Empty; 
 });
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 app.UseAuthentication();
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- avoid forcing HTTPS redirects when running in development so HTTP requests succeed

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d612f92acc83339bc65f5258c179c3