### PR TITLE
Fix schema and seed data for GET endpoint stability

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -1,6 +1,6 @@
+using System;
 using Microsoft.EntityFrameworkCore;
 using EcommerceBackend.Models;
-using BCrypt.Net;
 
 namespace EcommerceBackend.Data
 {
@@ -19,15 +19,19 @@ namespace EcommerceBackend.Data
         {
             base.OnModelCreating(modelBuilder);
 
-            // --- GUIDs generados dinámicamente ---
-            var adminId = Guid.NewGuid();
-            var userId = Guid.NewGuid();
-            var product1Id = Guid.NewGuid();
-            var product2Id = Guid.NewGuid();
-            var cartItemId = Guid.NewGuid();
-            var invoiceId = Guid.NewGuid();
-            var invoiceItemId = Guid.NewGuid();
-            var paymentId = Guid.NewGuid();
+            // --- Identificadores determinísticos para coincidir con las migraciones ---
+            var adminId = Guid.Parse("89b8105d-38e1-4849-abe3-d7c20b99d8a4");
+            var userId = Guid.Parse("d60ec960-bc53-424a-9128-5275fbd4969f");
+            var product1Id = Guid.Parse("488e5e0f-e6eb-44a3-a587-9c3e5f6c5e7b");
+            var product2Id = Guid.Parse("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6");
+            var cartItemId = Guid.Parse("1e8537ac-5a83-4f32-9ba5-248358dae55a");
+            var invoiceId = Guid.Parse("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006");
+            var invoiceItemId = Guid.Parse("c8633a68-aea5-4904-a9b5-5a15de248cc4");
+            var paymentId = Guid.Parse("cb361e92-3347-46f6-8568-8c1671dfbd8d");
+
+            var userCreatedAt = new DateTime(2025, 9, 21, 2, 19, 46, 202, DateTimeKind.Utc).AddTicks(1762);
+            var customerCreatedAt = new DateTime(2025, 9, 21, 2, 19, 46, 468, DateTimeKind.Utc).AddTicks(7329);
+            var productCreatedAt = new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc);
 
             // --- Usuarios ---
             modelBuilder.Entity<User>()
@@ -41,8 +45,9 @@ namespace EcommerceBackend.Data
                     Email = "admin@ecommerce.com",
                     NormalizedEmail = "admin@ecommerce.com",
                     FullName = "Admin",
-                    PasswordHash = BCrypt.Net.BCrypt.HashPassword("Admin123!"),
-                    Role = "admin"
+                    PasswordHash = "$2a$12$VCJVrEjQn17n3Vdd4QXdyOjRJr3BZ1M70Y/JlDlh.wur8H.nZwYYO.",
+                    Role = "admin",
+                    CreatedAt = userCreatedAt
                 },
                 new User
                 {
@@ -50,8 +55,9 @@ namespace EcommerceBackend.Data
                     Email = "user@ecommerce.com",
                     NormalizedEmail = "user@ecommerce.com",
                     FullName = "Usuario Test",
-                    PasswordHash = BCrypt.Net.BCrypt.HashPassword("User123!"),
-                    Role = "user"
+                    PasswordHash = "$2a$12$MwOFPEsAFNeID.N9x139jObpJuIlrXzIUMY/ASgGrxUDcLh80CT1W",
+                    Role = "user",
+                    CreatedAt = customerCreatedAt
                 }
             );
 
@@ -65,7 +71,8 @@ namespace EcommerceBackend.Data
                     Price = 1500m,
                     Stock = 10,
                     Category = "Electrónica",
-                    ImageUrl = ""
+                    ImageUrl = "",
+                    CreatedAt = productCreatedAt.AddTicks(4094)
                 },
                 new Product
                 {
@@ -75,7 +82,8 @@ namespace EcommerceBackend.Data
                     Price = 35m,
                     Stock = 50,
                     Category = "Accesorios",
-                    ImageUrl = ""
+                    ImageUrl = "",
+                    CreatedAt = productCreatedAt.AddTicks(4106)
                 }
             );
 
@@ -86,7 +94,8 @@ namespace EcommerceBackend.Data
                     Id = cartItemId,
                     UserId = userId,
                     ProductId = product2Id,
-                    Quantity = 2
+                    Quantity = 2,
+                    CreatedAt = productCreatedAt.AddTicks(4192)
                 }
             );
 
@@ -99,8 +108,10 @@ namespace EcommerceBackend.Data
                     InvoiceNumber = "INV-001",
                     Status = "Paid",
                     Total = 70m,
+                    Tax = 0m,
                     BillingAddress = "Calle Falsa 123",
-                    PaidAt = DateTime.UtcNow
+                    CreatedAt = productCreatedAt.AddTicks(4258),
+                    PaidAt = productCreatedAt.AddTicks(4267)
                 }
             );
 
@@ -127,7 +138,7 @@ namespace EcommerceBackend.Data
                     Provider = "Stripe",
                     ProviderPaymentId = "pay_001",
                     Status = "Completed",
-                    CreatedAt = DateTime.UtcNow
+                    CreatedAt = productCreatedAt.AddTicks(4383)
                 }
             );
         }

--- a/Migrations/20250921021947_SeedDataRailway.cs
+++ b/Migrations/20250921021947_SeedDataRailway.cs
@@ -19,11 +19,16 @@ namespace EcommerceBackend.Migrations
                     CREATE TABLE IF NOT EXISTS ""Users"" (
                         ""Id"" uuid PRIMARY KEY,
                         ""Email"" text NOT NULL,
+                        ""NormalizedEmail"" text NOT NULL DEFAULT '',
                         ""PasswordHash"" text NOT NULL,
                         ""FullName"" text NULL,
                         ""Role"" text NOT NULL,
                         ""CreatedAt"" timestamptz NOT NULL
                     );
+                ");
+                migrationBuilder.Sql(@"
+                    CREATE UNIQUE INDEX IF NOT EXISTS ""IX_Users_NormalizedEmail""
+                    ON ""Users"" (""NormalizedEmail"");
                 ");
 
                 migrationBuilder.Sql(@"
@@ -94,33 +99,116 @@ namespace EcommerceBackend.Migrations
                 ");
             }
 
-            // InsertData (igual que ya lo tienes después)...
-            var seedTimestamp = new DateTime(2025, 9, 21, 2, 19, 46, DateTimeKind.Utc);
+            var adminCreatedAt = new DateTime(2025, 9, 21, 2, 19, 46, 202, DateTimeKind.Utc).AddTicks(1762);
+            var userCreatedAt = new DateTime(2025, 9, 21, 2, 19, 46, 468, DateTimeKind.Utc).AddTicks(7329);
+            var seedBase = new DateTime(2025, 9, 21, 2, 19, 46, 692, DateTimeKind.Utc);
 
             migrationBuilder.InsertData(
                 table: "Users",
-                columns: new[] { "Id", "CreatedAt", "Email", "FullName", "PasswordHash", "Role" },
+                columns: new[] { "Id", "CreatedAt", "Email", "FullName", "NormalizedEmail", "PasswordHash", "Role" },
                 values: new object[,]
                 {
                     {
                         new Guid("89b8105d-38e1-4849-abe3-d7c20b99d8a4"),
-                        seedTimestamp,
+                        adminCreatedAt,
                         "admin@ecommerce.com",
                         "Admin",
-                        "$2a$11$a4XTN3Qs2Pls1KQrRWDlNOEEOLNW5Tn9lUHGYAl0wlgg5cYmHT4f.",
+                        "admin@ecommerce.com",
+                        "$2a$12$VCJVrEjQn17n3Vdd4QXdyOjRJr3BZ1M70Y/JlDlh.wur8H.nZwYYO.",
                         "admin"
                     },
                     {
                         new Guid("d60ec960-bc53-424a-9128-5275fbd4969f"),
-                        seedTimestamp,
+                        userCreatedAt,
                         "user@ecommerce.com",
                         "Usuario Test",
-                        "$2a$11$SBZkm5ho6nodxsu1bjQYKeV5rUlWPqwLMxNYvvSZtEkJRD4uHrSjm",
+                        "user@ecommerce.com",
+                        "$2a$12$MwOFPEsAFNeID.N9x139jObpJuIlrXzIUMY/ASgGrxUDcLh80CT1W",
                         "user"
                     }
                 });
 
-            // ... y el resto de Inserts igual
+            migrationBuilder.InsertData(
+                table: "Products",
+                columns: new[] { "Id", "Category", "CreatedAt", "Description", "ImageUrl", "Name", "Price", "Stock" },
+                values: new object[,]
+                {
+                    {
+                        new Guid("488e5e0f-e6eb-44a3-a587-9c3e5f6c5e7b"),
+                        "Electrónica",
+                        seedBase.AddTicks(4094),
+                        "Laptop potente para gaming",
+                        string.Empty,
+                        "Laptop Gamer",
+                        1500m,
+                        10
+                    },
+                    {
+                        new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                        "Accesorios",
+                        seedBase.AddTicks(4106),
+                        "Mouse Bluetooth ergonómico",
+                        string.Empty,
+                        "Mouse Inalámbrico",
+                        35m,
+                        50
+                    }
+                });
+
+            migrationBuilder.InsertData(
+                table: "CartItems",
+                columns: new[] { "Id", "CreatedAt", "ProductId", "Quantity", "UserId" },
+                values: new object[]
+                {
+                    new Guid("1e8537ac-5a83-4f32-9ba5-248358dae55a"),
+                    seedBase.AddTicks(4192),
+                    new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                    2,
+                    new Guid("d60ec960-bc53-424a-9128-5275fbd4969f")
+                });
+
+            migrationBuilder.InsertData(
+                table: "Invoices",
+                columns: new[] { "Id", "BillingAddress", "CreatedAt", "InvoiceNumber", "PaidAt", "Status", "Tax", "Total", "UserId" },
+                values: new object[]
+                {
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    "Calle Falsa 123",
+                    seedBase.AddTicks(4258),
+                    "INV-001",
+                    seedBase.AddTicks(4267),
+                    "Paid",
+                    0m,
+                    70m,
+                    new Guid("d60ec960-bc53-424a-9128-5275fbd4969f")
+                });
+
+            migrationBuilder.InsertData(
+                table: "InvoiceItems",
+                columns: new[] { "Id", "InvoiceId", "LineTotal", "ProductId", "Quantity", "UnitPrice" },
+                values: new object[]
+                {
+                    new Guid("c8633a68-aea5-4904-a9b5-5a15de248cc4"),
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    70m,
+                    new Guid("0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6"),
+                    2,
+                    35m
+                });
+
+            migrationBuilder.InsertData(
+                table: "Payments",
+                columns: new[] { "Id", "Amount", "CreatedAt", "InvoiceId", "Provider", "ProviderPaymentId", "Status" },
+                values: new object[]
+                {
+                    new Guid("cb361e92-3347-46f6-8568-8c1671dfbd8d"),
+                    70m,
+                    seedBase.AddTicks(4383),
+                    new Guid("d30b0c2c-d81c-4268-b9ff-1fcaebdb4006"),
+                    "Stripe",
+                    "pay_001",
+                    "Completed"
+                });
         }
 
         /// <inheritdoc />
@@ -129,6 +217,7 @@ namespace EcommerceBackend.Migrations
             if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
             {
                 migrationBuilder.Sql(@"DROP INDEX IF EXISTS ""IX_InvoiceItems_InvoiceId"";");
+                migrationBuilder.Sql(@"DROP INDEX IF EXISTS ""IX_Users_NormalizedEmail"";");
                 migrationBuilder.Sql(@"DROP TABLE IF EXISTS ""CartItems"" CASCADE;");
                 migrationBuilder.Sql(@"DROP TABLE IF EXISTS ""InvoiceItems"" CASCADE;");
                 migrationBuilder.Sql(@"DROP TABLE IF EXISTS ""Payments"" CASCADE;");

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 Ecommerce backend + frontend ready for Railway. See RAILWAY_INSTRUCTIONS.txt for deployment steps.
+
+## Database bootstrap
+
+The project now depends on the `NormalizedEmail` column for login and includes deterministic seed data for users, products, invoices, and payments. On clean environments you can either run the EF Core migrations or execute `initial_schema.sql` before starting the API.
+
+If you already provisioned a PostgreSQL database with an older schema, run the following once before redeploying:
+
+```sql
+ALTER TABLE "Users" ADD COLUMN IF NOT EXISTS "NormalizedEmail" text NOT NULL DEFAULT '';
+UPDATE "Users" SET "NormalizedEmail" = lower("Email") WHERE coalesce("NormalizedEmail", '') = '';
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_Users_NormalizedEmail" ON "Users" ("NormalizedEmail");
+```
+
+Afterwards, re-run the migrations (`dotnet ef database update` locally or restart the Railway service) so that the deterministic seed records are inserted and GET endpoints stop returning 500 due to missing tables or rows.

--- a/initial_schema.sql
+++ b/initial_schema.sql
@@ -2,11 +2,13 @@
 CREATE TABLE IF NOT EXISTS "Users" (
   "Id" uuid PRIMARY KEY,
   "Email" varchar(256) NOT NULL UNIQUE,
+  "NormalizedEmail" varchar(256) NOT NULL DEFAULT '',
   "PasswordHash" varchar(512) NOT NULL,
   "FullName" varchar(200),
   "Role" varchar(50),
   "CreatedAt" timestamptz DEFAULT now()
 );
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_Users_NormalizedEmail" ON "Users" ("NormalizedEmail");
 CREATE TABLE IF NOT EXISTS "Products" (
   "Id" uuid PRIMARY KEY,
   "Name" varchar(200) NOT NULL,
@@ -43,6 +45,7 @@ CREATE TABLE IF NOT EXISTS "InvoiceItems" (
   "UnitPrice" numeric(18,2) NOT NULL,
   "LineTotal" numeric(18,2) NOT NULL
 );
+CREATE INDEX IF NOT EXISTS "IX_InvoiceItems_InvoiceId" ON "InvoiceItems" ("InvoiceId");
 CREATE TABLE IF NOT EXISTS "Payments" (
   "Id" uuid PRIMARY KEY,
   "InvoiceId" uuid REFERENCES "Invoices"("Id"),
@@ -52,3 +55,29 @@ CREATE TABLE IF NOT EXISTS "Payments" (
   "Status" varchar(50),
   "CreatedAt" timestamptz DEFAULT now()
 );
+
+INSERT INTO "Users" ("Id", "Email", "NormalizedEmail", "PasswordHash", "FullName", "Role", "CreatedAt") VALUES
+  ('89b8105d-38e1-4849-abe3-d7c20b99d8a4', 'admin@ecommerce.com', 'admin@ecommerce.com', '$2a$12$VCJVrEjQn17n3Vdd4QXdyOjRJr3BZ1M70Y/JlDlh.wur8H.nZwYYO.', 'Admin', 'admin', '2025-09-21 02:19:46.202176+00'),
+  ('d60ec960-bc53-424a-9128-5275fbd4969f', 'user@ecommerce.com', 'user@ecommerce.com', '$2a$12$MwOFPEsAFNeID.N9x139jObpJuIlrXzIUMY/ASgGrxUDcLh80CT1W', 'Usuario Test', 'user', '2025-09-21 02:19:46.468733+00')
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "Products" ("Id", "Name", "Description", "Price", "Stock", "Category", "ImageUrl", "CreatedAt") VALUES
+  ('488e5e0f-e6eb-44a3-a587-9c3e5f6c5e7b', 'Laptop Gamer', 'Laptop potente para gaming', 1500, 10, 'Electrónica', '', '2025-09-21 02:19:46.692409+00'),
+  ('0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6', 'Mouse Inalámbrico', 'Mouse Bluetooth ergonómico', 35, 50, 'Accesorios', '', '2025-09-21 02:19:46.692411+00')
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "CartItems" ("Id", "UserId", "ProductId", "Quantity", "CreatedAt") VALUES
+  ('1e8537ac-5a83-4f32-9ba5-248358dae55a', 'd60ec960-bc53-424a-9128-5275fbd4969f', '0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6', 2, '2025-09-21 02:19:46.692419+00')
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "Invoices" ("Id", "UserId", "InvoiceNumber", "Total", "Tax", "Status", "CreatedAt", "PaidAt", "BillingAddress") VALUES
+  ('d30b0c2c-d81c-4268-b9ff-1fcaebdb4006', 'd60ec960-bc53-424a-9128-5275fbd4969f', 'INV-001', 70, 0, 'Paid', '2025-09-21 02:19:46.692426+00', '2025-09-21 02:19:46.692427+00', 'Calle Falsa 123')
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "InvoiceItems" ("Id", "InvoiceId", "ProductId", "Quantity", "UnitPrice", "LineTotal") VALUES
+  ('c8633a68-aea5-4904-a9b5-5a15de248cc4', 'd30b0c2c-d81c-4268-b9ff-1fcaebdb4006', '0dd2df11-f26b-4b0a-bd2a-eb9f1c1f94f6', 2, 35, 70)
+ON CONFLICT ("Id") DO NOTHING;
+
+INSERT INTO "Payments" ("Id", "InvoiceId", "Provider", "ProviderPaymentId", "Amount", "Status", "CreatedAt") VALUES
+  ('cb361e92-3347-46f6-8568-8c1671dfbd8d', 'd30b0c2c-d81c-4268-b9ff-1fcaebdb4006', 'Stripe', 'pay_001', 70, 'Completed', '2025-09-21 02:19:46.692438+00')
+ON CONFLICT ("Id") DO NOTHING;


### PR DESCRIPTION
## Summary
- switch `AppDbContext` seeding to deterministic identifiers and precomputed hashes so EF migrations and runtime seeds stay aligned
- update the Railway bootstrap migration and `initial_schema.sql` to add the `NormalizedEmail` column plus full product/cart/invoice/payment seed data
- document the one-time SQL needed to backfill existing databases with the normalized email index before redeploying

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d617cc63948333b492a7a50202bb83