### PR TITLE
Centralize default JWT key configuration

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,16 +39,7 @@ if (string.IsNullOrWhiteSpace(conn))
 builder.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(conn));
 
 // JWT
-var jwtKey = builder.Configuration["Jwt:Key"]
-              ?? Environment.GetEnvironmentVariable("Jwt__Key")
-              ?? "development-secret-key-change-me";
-
-if (jwtKey.Length < 16)
-{
-    throw new InvalidOperationException(
-        "JWT key must be at least 16 characters long. Set Jwt:Key/Jwt__Key to a secure value.");
-}
-
+var jwtKey = JwtKeyProvider.GetSigningKey(builder.Configuration);
 var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/Security/JwtKeyProvider.cs
+++ b/Security/JwtKeyProvider.cs
@@ -7,6 +7,7 @@ namespace EcommerceBackend.Security
     public static class JwtKeyProvider
     {
         private const int MinimumKeyBytes = 16;
+        public const string DefaultDevelopmentKey = "development-secret-key-change-me";
 
         public static string GetSigningKey(IConfiguration configuration)
         {
@@ -14,9 +15,7 @@ namespace EcommerceBackend.Security
 
             if (string.IsNullOrWhiteSpace(key))
             {
-                throw new InvalidOperationException(
-                    "A JWT signing key was not configured. Provide a value for 'Jwt:Key' or the 'Jwt__Key' environment variable."
-                );
+                key = DefaultDevelopmentKey;
             }
 
             if (Encoding.UTF8.GetByteCount(key) < MinimumKeyBytes)


### PR DESCRIPTION
## Summary
- centralize the development JWT key in `JwtKeyProvider`
- reuse the shared key accessor when configuring JWT authentication in `Program`

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d714e45a788333ab153284976a30b9