### PR TITLE
Handle PostgreSQL idempotency for normalized email migration

### DIFF
--- a/Migrations/20250922000000_AddNormalizedEmailToUsers.cs
+++ b/Migrations/20250922000000_AddNormalizedEmailToUsers.cs
@@ -10,32 +10,49 @@ namespace EcommerceBackend.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "NormalizedEmail",
-                table: "Users",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
+            if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.Sql("ALTER TABLE \"Users\" ADD COLUMN IF NOT EXISTS \"NormalizedEmail\" text NOT NULL DEFAULT '';");
+                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(\"Email\") WHERE COALESCE(\"NormalizedEmail\", '') = '';");
+                migrationBuilder.Sql("CREATE UNIQUE INDEX IF NOT EXISTS \"IX_Users_NormalizedEmail\" ON \"Users\" (\"NormalizedEmail\");");
+            }
+            else
+            {
+                migrationBuilder.AddColumn<string>(
+                    name: "NormalizedEmail",
+                    table: "Users",
+                    type: "text",
+                    nullable: false,
+                    defaultValue: "");
 
-            migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(\"Email\");");
+                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(\"Email\");");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Users_NormalizedEmail",
-                table: "Users",
-                column: "NormalizedEmail",
-                unique: true);
+                migrationBuilder.CreateIndex(
+                    name: "IX_Users_NormalizedEmail",
+                    table: "Users",
+                    column: "NormalizedEmail",
+                    unique: true);
+            }
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Users_NormalizedEmail",
-                table: "Users");
+            if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
+            {
+                migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_Users_NormalizedEmail\";");
+                migrationBuilder.Sql("ALTER TABLE \"Users\" DROP COLUMN IF EXISTS \"NormalizedEmail\";");
+            }
+            else
+            {
+                migrationBuilder.DropIndex(
+                    name: "IX_Users_NormalizedEmail",
+                    table: "Users");
 
-            migrationBuilder.DropColumn(
-                name: "NormalizedEmail",
-                table: "Users");
+                migrationBuilder.DropColumn(
+                    name: "NormalizedEmail",
+                    table: "Users");
+            }
         }
     }
 }

--- a/Migrations/20250922000000_AddNormalizedEmailToUsers.cs
+++ b/Migrations/20250922000000_AddNormalizedEmailToUsers.cs
@@ -13,7 +13,8 @@ namespace EcommerceBackend.Migrations
             if (migrationBuilder.ActiveProvider == "Npgsql.EntityFrameworkCore.PostgreSQL")
             {
                 migrationBuilder.Sql("ALTER TABLE \"Users\" ADD COLUMN IF NOT EXISTS \"NormalizedEmail\" text NOT NULL DEFAULT '';");
-                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(\"Email\") WHERE COALESCE(\"NormalizedEmail\", '') = '';");
+                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(trim(\"Email\")) WHERE COALESCE(\"NormalizedEmail\", '') = '' OR \"NormalizedEmail\" <> lower(trim(\"Email\"));");
+                migrationBuilder.Sql("ALTER TABLE \"Users\" ALTER COLUMN \"NormalizedEmail\" DROP DEFAULT;");
                 migrationBuilder.Sql("CREATE UNIQUE INDEX IF NOT EXISTS \"IX_Users_NormalizedEmail\" ON \"Users\" (\"NormalizedEmail\");");
             }
             else
@@ -25,7 +26,7 @@ namespace EcommerceBackend.Migrations
                     nullable: false,
                     defaultValue: "");
 
-                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(\"Email\");");
+                migrationBuilder.Sql("UPDATE \"Users\" SET \"NormalizedEmail\" = lower(trim(\"Email\"));");
 
                 migrationBuilder.CreateIndex(
                     name: "IX_Users_NormalizedEmail",


### PR DESCRIPTION
## Summary
- add PostgreSQL-specific SQL in the AddNormalizedEmail migration so the column and index are created idempotently after seed data
- mirror provider-specific logic in the Down migration path to safely drop the objects on PostgreSQL

## Testing
- `dotnet ef database update` *(fails: `dotnet` CLI not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d717835b948333a97327dc8519d4c4