### PR TITLE
Ensure JWT key configuration fallback

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,9 +39,22 @@ if (string.IsNullOrWhiteSpace(conn))
 builder.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(conn));
 
 // JWT
-var jwtKey = builder.Configuration["Jwt:Key"]
-              ?? Environment.GetEnvironmentVariable("Jwt__Key")
-              ?? "development-secret-key-change-me";
+var jwtKey = builder.Configuration["Jwt:Key"];
+
+if (string.IsNullOrWhiteSpace(jwtKey))
+{
+    jwtKey = Environment.GetEnvironmentVariable("Jwt__Key");
+}
+
+if (string.IsNullOrWhiteSpace(jwtKey))
+{
+    jwtKey = JwtKeyProvider.DevelopmentFallbackKey;
+}
+
+if (string.IsNullOrWhiteSpace(builder.Configuration["Jwt:Key"]))
+{
+    builder.Configuration["Jwt:Key"] = jwtKey;
+}
 
 if (jwtKey.Length < 16)
 {

--- a/Security/JwtKeyProvider.cs
+++ b/Security/JwtKeyProvider.cs
@@ -6,11 +6,27 @@ namespace EcommerceBackend.Security
 {
     public static class JwtKeyProvider
     {
+        public const string DevelopmentFallbackKey = "development-secret-key-change-me";
         private const int MinimumKeyBytes = 16;
 
         public static string GetSigningKey(IConfiguration configuration)
         {
-            var key = configuration["Jwt:Key"] ?? Environment.GetEnvironmentVariable("Jwt__Key");
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var key = configuration["Jwt:Key"];
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = Environment.GetEnvironmentVariable("Jwt__Key");
+            }
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                key = DevelopmentFallbackKey;
+            }
 
             if (string.IsNullOrWhiteSpace(key))
             {
@@ -25,6 +41,8 @@ namespace EcommerceBackend.Security
                     "The configured JWT signing key must be at least 16 bytes long when encoded as UTF-8."
                 );
             }
+
+            configuration["Jwt:Key"] = key;
 
             return key;
         }


### PR DESCRIPTION
## Summary
- ensure the runtime configuration writes back the resolved JWT signing key when the configured value is missing
- centralize the development fallback key and allow JwtKeyProvider to fall back to environment or default values safely

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d71a5ac0448333a6a3d9a48be34fa1