### PR TITLE
Improve database connection resilience

### DIFF
--- a/Configuration/ConnectionStringResolver.cs
+++ b/Configuration/ConnectionStringResolver.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace EcommerceBackend.Configuration;
+
+public static class ConnectionStringResolver
+{
+    private const string LocalFallback = "Host=localhost;Port=5432;Database=ecommercedb;Username=postgres;Password=postgres";
+
+    public static string Resolve(IConfiguration configuration)
+    {
+        var envConnection = Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection");
+        if (!string.IsNullOrWhiteSpace(envConnection))
+        {
+            return envConnection;
+        }
+
+        var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
+        if (!string.IsNullOrWhiteSpace(databaseUrl))
+        {
+            return BuildConnectionStringFromUrl(databaseUrl);
+        }
+
+        var configuredConnection = configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrWhiteSpace(configuredConnection))
+        {
+            return LocalFallback;
+        }
+
+        if (RequiresRailwayFallback(configuredConnection))
+        {
+            return LocalFallback;
+        }
+
+        return configuredConnection;
+    }
+
+    private static bool RequiresRailwayFallback(string connectionString)
+    {
+        if (!TryGetHost(connectionString, out var host))
+        {
+            return false;
+        }
+
+        if (!host.EndsWith(".railway.internal", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return !CanResolve(host);
+    }
+
+    private static bool TryGetHost(string connectionString, out string host)
+    {
+        host = string.Empty;
+        try
+        {
+            var builder = new NpgsqlConnectionStringBuilder(connectionString);
+            if (string.IsNullOrWhiteSpace(builder.Host))
+            {
+                return false;
+            }
+
+            host = builder.Host;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool CanResolve(string host)
+    {
+        try
+        {
+            _ = Dns.GetHostEntry(host);
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+    }
+
+    public static string BuildConnectionStringFromUrl(string databaseUrl)
+    {
+        if (!Uri.TryCreate(databaseUrl, UriKind.Absolute, out var uri))
+        {
+            return databaseUrl;
+        }
+
+        var host = uri.Host;
+        var port = uri.IsDefaultPort ? 5432 : uri.Port;
+        var database = uri.AbsolutePath.Trim('/');
+
+        var userInfo = uri.UserInfo.Split(':', 2);
+        var username = userInfo.Length > 0 ? Uri.UnescapeDataString(userInfo[0]) : string.Empty;
+        var password = userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty;
+
+        var sslMode = uri.Scheme.StartsWith("postgres", StringComparison.OrdinalIgnoreCase)
+            ? "Require"
+            : "Disable";
+
+        return $"Host={host};Port={port};Database={database};Username={username};Password={password};Ssl Mode={sslMode};Trust Server Certificate=true";
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using EcommerceBackend.Configuration;
 using EcommerceBackend.Data;
 using EcommerceBackend.Services;
 using EcommerceBackend.Security;
@@ -18,24 +19,8 @@ builder.Services.AddSwaggerGen(c =>
 });
 builder.Services.AddScoped<TokenService>();
 
-// DB - Connection string from env: ConnectionStrings__DefaultConnection or DATABASE_URL
-var conn = builder.Configuration.GetConnectionString("DefaultConnection")
-           ?? Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection");
-
-if (string.IsNullOrWhiteSpace(conn))
-{
-    var databaseUrl = Environment.GetEnvironmentVariable("DATABASE_URL");
-    if (!string.IsNullOrWhiteSpace(databaseUrl))
-    {
-        conn = BuildConnectionStringFromUrl(databaseUrl);
-    }
-}
-
-if (string.IsNullOrWhiteSpace(conn))
-{
-    // fallback local for development
-    conn = "Host=localhost;Port=5432;Database=ecommercedb;Username=postgres;Password=postgres";
-}
+// DB - resolve connection string automatically with sane fallbacks
+var conn = ConnectionStringResolver.Resolve(builder.Configuration);
 builder.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(conn));
 
 // JWT
@@ -96,25 +81,3 @@ using (var scope = app.Services.CreateScope())
 }
 
 app.Run();
-
-static string BuildConnectionStringFromUrl(string databaseUrl)
-{
-    if (!Uri.TryCreate(databaseUrl, UriKind.Absolute, out var uri))
-    {
-        return databaseUrl;
-    }
-
-    var host = uri.Host;
-    var port = uri.IsDefaultPort ? 5432 : uri.Port;
-    var database = uri.AbsolutePath.Trim('/');
-
-    var userInfo = uri.UserInfo.Split(':', 2);
-    var username = userInfo.Length > 0 ? Uri.UnescapeDataString(userInfo[0]) : string.Empty;
-    var password = userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty;
-
-    var sslMode = uri.Scheme.StartsWith("postgres", StringComparison.OrdinalIgnoreCase)
-        ? "Require"
-        : "Disable";
-
-    return $"Host={host};Port={port};Database={database};Username={username};Password={password};Ssl Mode={sslMode};Trust Server Certificate=true";
-}


### PR DESCRIPTION
## Summary
- add a connection string resolver that falls back to a local Postgres instance when the Railway host is unreachable
- keep support for DATABASE_URL parsing so deployments can still rely on environment-provided URLs
- update Program.cs to use the centralized resolver when configuring the DbContext

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d71e49a7d88333a941fb7854744bc4