### PR TITLE
Enforce 256-bit minimum JWT signing key

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -43,10 +43,10 @@ var jwtKey = builder.Configuration["Jwt:Key"]
               ?? Environment.GetEnvironmentVariable("Jwt__Key")
               ?? "development-secret-key-change-me";
 
-if (jwtKey.Length < 16)
+if (Encoding.UTF8.GetByteCount(jwtKey) < 32)
 {
     throw new InvalidOperationException(
-        "JWT key must be at least 16 characters long. Set Jwt:Key/Jwt__Key to a secure value.");
+        "JWT key must be at least 32 bytes long. Set Jwt:Key/Jwt__Key to a secure value.");
 }
 
 var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));

--- a/Security/JwtKeyProvider.cs
+++ b/Security/JwtKeyProvider.cs
@@ -6,7 +6,7 @@ namespace EcommerceBackend.Security
 {
     public static class JwtKeyProvider
     {
-        private const int MinimumKeyBytes = 16;
+        private const int MinimumKeyBytes = 32;
 
         public static string GetSigningKey(IConfiguration configuration)
         {
@@ -22,7 +22,7 @@ namespace EcommerceBackend.Security
             if (Encoding.UTF8.GetByteCount(key) < MinimumKeyBytes)
             {
                 throw new InvalidOperationException(
-                    "The configured JWT signing key must be at least 16 bytes long when encoded as UTF-8."
+                    "The configured JWT signing key must be at least 32 bytes long when encoded as UTF-8."
                 );
             }
 


### PR DESCRIPTION
## Summary
- require JWT secrets to be at least 32 bytes when configuring authentication and retrieving signing keys to satisfy HS256 requirements

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d72c11b1988333bfe13389123b4094