### PR TITLE
Enforce HS256 JWT key length requirements

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -39,16 +39,7 @@ if (string.IsNullOrWhiteSpace(conn))
 builder.Services.AddDbContext<AppDbContext>(opt => opt.UseNpgsql(conn));
 
 // JWT
-var jwtKey = builder.Configuration["Jwt:Key"]
-              ?? Environment.GetEnvironmentVariable("Jwt__Key")
-              ?? "development-secret-key-change-me";
-
-if (jwtKey.Length < 16)
-{
-    throw new InvalidOperationException(
-        "JWT key must be at least 16 characters long. Set Jwt:Key/Jwt__Key to a secure value.");
-}
-
+var jwtKey = JwtKeyProvider.GetSigningKey(builder.Configuration);
 var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/Security/JwtKeyProvider.cs
+++ b/Security/JwtKeyProvider.cs
@@ -6,7 +6,13 @@ namespace EcommerceBackend.Security
 {
     public static class JwtKeyProvider
     {
-        private const int MinimumKeyBytes = 16;
+        private const int MinimumKeyBytes = 32;
+        public const string DefaultDevelopmentKey = "P#s8!nZ7@wF$hV9gY2kR&qL4jM3pA5uC6bE";
+
+        /// <summary>
+        /// A fallback key that can be used during development when no key has been configured.
+        /// </summary>
+        public static string DevelopmentFallbackKey => DefaultDevelopmentKey;
 
         public static string GetSigningKey(IConfiguration configuration)
         {
@@ -14,15 +20,13 @@ namespace EcommerceBackend.Security
 
             if (string.IsNullOrWhiteSpace(key))
             {
-                throw new InvalidOperationException(
-                    "A JWT signing key was not configured. Provide a value for 'Jwt:Key' or the 'Jwt__Key' environment variable."
-                );
+                key = DevelopmentFallbackKey;
             }
 
             if (Encoding.UTF8.GetByteCount(key) < MinimumKeyBytes)
             {
                 throw new InvalidOperationException(
-                    "The configured JWT signing key must be at least 16 bytes long when encoded as UTF-8."
+                    "The configured JWT signing key must be at least 32 bytes (256 bits) when encoded as UTF-8 for HS256."
                 );
             }
 


### PR DESCRIPTION
## Summary
- raise the shared JwtKeyProvider minimum signing key length to 32 bytes to align with HS256 requirements
- seed the development fallback signing key with a 256-bit secret so local builds start with a valid HS256 key

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d730de2ffc8333a8f36e3dc0a057f0