### PR TITLE
Handle JWT claim mapping when resolving the authenticated user

### DIFF
--- a/Controllers/CartController.cs
+++ b/Controllers/CartController.cs
@@ -21,7 +21,8 @@ namespace EcommerceBackend.Controllers
         private bool TryGetUserId(out Guid userId)
         {
             userId = Guid.Empty;
-            var subject = User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            var subject = User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
             return !string.IsNullOrWhiteSpace(subject) && Guid.TryParse(subject, out userId);
         }
 

--- a/Controllers/InvoicesController.cs
+++ b/Controllers/InvoicesController.cs
@@ -20,7 +20,8 @@ namespace EcommerceBackend.Controllers
         private bool TryGetUserId(out Guid userId)
         {
             userId = Guid.Empty;
-            var subject = User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub);
+            var subject = User.FindFirstValue(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub)
+                ?? User.FindFirstValue(ClaimTypes.NameIdentifier);
             return !string.IsNullOrWhiteSpace(subject) && Guid.TryParse(subject, out userId);
         }
 


### PR DESCRIPTION
## Summary
- allow cart and invoice controllers to read the user id from either the JWT `sub` claim or the mapped name identifier claim
- ensure authenticated users remain recognized after the framework maps standard JWT claims

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7352aa14083338f4c6a191e725d12